### PR TITLE
add filter prop to collections

### DIFF
--- a/src/FirestoreCollection.js
+++ b/src/FirestoreCollection.js
@@ -6,6 +6,10 @@ class FirestoreCollection extends Component {
     path: PropTypes.string.isRequired,
     sort: PropTypes.string,
     limit: PropTypes.number,
+    filter: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.string),
+      PropTypes.arrayOf(PropTypes.array),
+    ]),
     render: PropTypes.func.isRequired,
   };
 
@@ -51,7 +55,7 @@ class FirestoreCollection extends Component {
   };
 
   buildQuery = (collectionRef, queryProps) => {
-    const { sort, limit } = queryProps;
+    const { sort, limit, filter } = queryProps;
     let query = collectionRef;
 
     if (sort) {
@@ -64,6 +68,18 @@ class FirestoreCollection extends Component {
 
     if (limit) {
       query = query.limit(limit);
+    }
+
+    if (filter) {
+      //if filter is array of array, build the compound query
+      if (Array.isArray(filter[0])) {
+        filter.forEach(clause => {
+          query = query.where(...clause);
+        });
+      } else {
+        //build the simple query
+        query = query.where(...filter);
+      }
     }
 
     return query;

--- a/src/__tests__/collection.filter.js
+++ b/src/__tests__/collection.filter.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { FirestoreCollection } from '../';
+import { createMocksForCollection } from './helpers/firestore-utils';
+
+test('filters the documents returned with a simple filter', () => {
+  const {
+    firestoreMock,
+    collectionMock,
+    query,
+    onSnapshotMock,
+  } = createMocksForCollection();
+  const renderMock = jest.fn().mockReturnValue(<div />);
+  const collectionName = 'users';
+  const filter = ['name', '==', 'Mike'];
+
+  mount(
+    <FirestoreCollection
+      path={collectionName}
+      filter={filter}
+      render={renderMock}
+    />,
+    { context: { firestoreDatabase: firestoreMock, firestoreCache: {} } },
+  );
+
+  expect(collectionMock).toHaveBeenCalledTimes(1);
+  expect(collectionMock).toHaveBeenCalledWith(collectionName);
+  expect(query.where).toHaveBeenCalledTimes(1);
+  expect(query.where).toHaveBeenCalledWith(...filter);
+  expect(onSnapshotMock).toHaveBeenCalledTimes(1);
+  expect(renderMock).toHaveBeenCalledTimes(1);
+  expect(renderMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      isLoading: true,
+      data: [],
+    }),
+  );
+});
+
+test('filters the documents returned with a compound filter', () => {
+  const {
+    firestoreMock,
+    collectionMock,
+    query,
+    onSnapshotMock,
+  } = createMocksForCollection();
+  const renderMock = jest.fn().mockReturnValue(<div />);
+  const collectionName = 'users';
+  const filter = [['firstName', '==', 'Mike'], ['lastName', '==', 'Smith']];
+
+  mount(
+    <FirestoreCollection
+      path={collectionName}
+      filter={filter}
+      render={renderMock}
+    />,
+    { context: { firestoreDatabase: firestoreMock, firestoreCache: {} } },
+  );
+
+  expect(collectionMock).toHaveBeenCalledTimes(1);
+  expect(collectionMock).toHaveBeenCalledWith(collectionName);
+  expect(query.where).toHaveBeenCalledTimes(2);
+  expect(onSnapshotMock).toHaveBeenCalledTimes(1);
+  expect(renderMock).toHaveBeenCalledTimes(1);
+  expect(renderMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      isLoading: true,
+      data: [],
+    }),
+  );
+});

--- a/src/__tests__/collection.filter.js
+++ b/src/__tests__/collection.filter.js
@@ -60,6 +60,8 @@ test('filters the documents returned with a compound filter', () => {
   expect(collectionMock).toHaveBeenCalledTimes(1);
   expect(collectionMock).toHaveBeenCalledWith(collectionName);
   expect(query.where).toHaveBeenCalledTimes(2);
+  expect(query.where).toHaveBeenCalledWith(...filter[0]);
+  expect(query.where).toHaveBeenCalledWith(...filter[1]);
   expect(onSnapshotMock).toHaveBeenCalledTimes(1);
   expect(renderMock).toHaveBeenCalledTimes(1);
   expect(renderMock).toHaveBeenCalledWith(

--- a/src/__tests__/helpers/firestore-utils.js
+++ b/src/__tests__/helpers/firestore-utils.js
@@ -44,6 +44,7 @@ function createBaseMocks(snapshot) {
 
   query.orderBy = jest.fn().mockReturnValue(query);
   query.limit = jest.fn().mockReturnValue(query);
+  query.where = jest.fn().mockReturnValue(query);
 
   const collectionMock = jest.fn().mockReturnValue(query);
   const documentMock = jest


### PR DESCRIPTION
This fixes #2.

Passing in an array of strings creates a simple query
```
<FirestoreCollection
      path={"users"}
      filter={['firstName', '==', 'Mike']}
      render={()=>{/* render stuff*/}}
    />
```

Passing in an array of arrays creates a compound query
```
<FirestoreCollection
      path={"users"}
      filter={[['firstName', '==', 'Mike'], ['lastName', '==', 'Smith']]}
      render={()=>{/* render stuff*/}}
    />
```