### PR TITLE
Allow numbers and objects in filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,22 @@ Passing in an array of arrays creates a compound query to filter the collection 
 />
 ```
 
+Passing in document references allows you to filter by reference fields:
+
+```jsx
+<FirestoreCollection
+  path={'users'}
+  filter={[
+    'organization',
+    '==',
+    firestore.collection('organizations').doc('foocorp'),
+  ]}
+  render={() => {
+    /* render stuff*/
+  }}
+/>
+```
+
 ##### render
 
 > function({}) | _required_

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import firebase from '@firebase/app';
 import '@firebase/firestore';
-import { FirestoreProvider } from "react-firestore";
+import { FirestoreProvider } from 'react-firestore';
 
 import App from './App';
 
@@ -183,21 +183,27 @@ The maximum number of documents to retrieve from the collection.
 > `array` or `array of array` | defaults to `null`
 
 Passing in an array of strings creates a simple query to filter the collection by
+
 ```jsx
 <FirestoreCollection
-      path={"users"}
-      filter={['firstName', '==', 'Mike']}
-      render={()=>{/* render stuff*/}}
-    />
+  path={'users'}
+  filter={['firstName', '==', 'Mike']}
+  render={() => {
+    /* render stuff*/
+  }}
+/>
 ```
 
 Passing in an array of arrays creates a compound query to filter the collection by
+
 ```jsx
 <FirestoreCollection
-      path={"users"}
-      filter={[['firstName', '==', 'Mike'], ['lastName', '==', 'Smith']]}
-      render={()=>{/* render stuff*/}}
-    />
+  path={'users'}
+  filter={[['firstName', '==', 'Mike'], ['lastName', '==', 'Smith']]}
+  render={() => {
+    /* render stuff*/
+  }}
+/>
 ```
 
 ##### render
@@ -287,8 +293,8 @@ or if you would just rather interact directly with the `firestore` object.
 This is the function where you render whatever you want using the firestore
 object passed in.
 
-| property  | type     | description                                                                                                                           |
-| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| property  | type     | description                                                                                                                                   |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | firestore | `Object` | The `Firestore` class from [firestore][firestore-package]. See the docs for the [Firestore class][firestore-class-docs] for more information. |
 
 ### `withFirestore`
@@ -299,7 +305,7 @@ directly to the wrapped component via the `firestore` prop.
 ```jsx
 class MyComponent extends Component {
   state = {
-    story: null
+    story: null,
   };
 
   componentDidMount() {

--- a/src/FirestoreCollection.js
+++ b/src/FirestoreCollection.js
@@ -8,7 +8,13 @@ class FirestoreCollection extends Component {
     sort: PropTypes.string,
     limit: PropTypes.number,
     filter: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.string),
+      PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.number,
+          PropTypes.object,
+        ]),
+      ),
       PropTypes.arrayOf(PropTypes.array),
     ]),
     children: PropTypes.func,

--- a/src/__tests__/collection.filter.js
+++ b/src/__tests__/collection.filter.js
@@ -71,3 +71,25 @@ test('filters the documents returned with a compound filter', () => {
     }),
   );
 });
+
+test('filter accepts objects and numbers', () => {
+  const { firestoreMock } = createMocksForCollection();
+  const renderMock = jest.fn().mockReturnValue(<div />);
+  const collectionName = 'users';
+  mount(
+    <FirestoreCollection
+      path={collectionName}
+      filter={['number', '==', 5]}
+      render={renderMock}
+    />,
+    { context: { firestoreDatabase: firestoreMock, firestoreCache: {} } },
+  );
+  mount(
+    <FirestoreCollection
+      path={collectionName}
+      filter={['ref', '==', firestoreMock.doc('things/foobar')]}
+      render={renderMock}
+    />,
+    { context: { firestoreDatabase: firestoreMock, firestoreCache: {} } },
+  );
+});


### PR DESCRIPTION
For example: `filter={["thing", "==", db.doc("things/" + thing)]}`

Fixes #16