### PR TITLE
Expose firestore query errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "react-firestore",
   "version": "0.0.0-semantically-released",
-  "description":
-    "React components to fetch data from firestore using render props",
+  "description": "React components to fetch data from firestore using render props",
   "author": "Andrew Walton",
   "license": "MIT",
   "homepage": "https://github.com/green-arrow/react-firestore#readme",
@@ -28,7 +27,10 @@
     "precommit": "kcd-scripts precommit",
     "prepare": "npm run build"
   },
-  "files": ["dist", "preact"],
+  "files": [
+    "dist",
+    "preact"
+  ],
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",
     "rules": {
@@ -36,11 +38,22 @@
       "no-eq-null": "off",
       "eqeqeq": "off",
       "react/jsx-indent": "off",
-      "complexity": ["error", 12]
+      "complexity": [
+        "error",
+        12
+      ]
     }
   },
-  "eslintIgnore": ["node_modules", "coverage", "dist"],
-  "keywords": ["react", "firestore", "firebase"],
+  "eslintIgnore": [
+    "node_modules",
+    "coverage",
+    "dist"
+  ],
+  "keywords": [
+    "react",
+    "firestore",
+    "firebase"
+  ],
   "dependencies": {
     "hoist-non-react-statics": "^2.3.1"
   },

--- a/src/FirestoreCollection.js
+++ b/src/FirestoreCollection.js
@@ -29,6 +29,7 @@ class FirestoreCollection extends Component {
   state = {
     isLoading: true,
     data: [],
+    error: null,
     snapshot: null,
   };
 
@@ -67,17 +68,32 @@ class FirestoreCollection extends Component {
     const collectionRef = firestoreDatabase.collection(path);
     const query = this.buildQuery(collectionRef, queryProps);
 
-    this.unsubscribe = query.onSnapshot(snapshot => {
-      if (snapshot) {
-        this.setState({
-          isLoading: false,
-          data: snapshot.docs.map(doc => ({
-            id: doc.id,
-            ...doc.data(),
-          })),
-          snapshot,
-        });
-      }
+    this.unsubscribe = query.onSnapshot(
+      this.handleOnSnapshotSuccess,
+      this.handleOnSnapshotError,
+    );
+  };
+
+  handleOnSnapshotSuccess = snapshot => {
+    if (snapshot) {
+      this.setState({
+        isLoading: false,
+        data: snapshot.docs.map(doc => ({
+          id: doc.id,
+          ...doc.data(),
+        })),
+        error: null,
+        snapshot,
+      });
+    }
+  };
+
+  handleOnSnapshotError = error => {
+    this.setState({
+      isLoading: false,
+      data: [],
+      error,
+      snapshot: null,
     });
   };
 

--- a/src/FirestoreDocument.js
+++ b/src/FirestoreDocument.js
@@ -16,6 +16,7 @@ class FirestoreDocument extends Component {
   state = {
     isLoading: true,
     data: null,
+    error: null,
     snapshot: null,
   };
 
@@ -48,18 +49,33 @@ class FirestoreDocument extends Component {
     const { path } = props;
     const documentRef = firestoreDatabase.doc(path);
 
-    this.unsubscribe = documentRef.onSnapshot(snapshot => {
-      if (snapshot) {
-        this.setState({
-          isLoading: false,
-          data: {
-            id: snapshot.id,
-            ...snapshot.data(),
-          },
-          snapshot,
-        });
-      }
+    this.unsubscribe = documentRef.onSnapshot(
+      this.handleOnSnapshotSuccess,
+      this.handleOnSnapshotError,
+    );
+  };
+
+  handleOnSnapshotError = error => {
+    this.setState({
+      isLoading: false,
+      error,
+      data: null,
+      snapshot: null,
     });
+  };
+
+  handleOnSnapshotSuccess = snapshot => {
+    if (snapshot) {
+      this.setState({
+        isLoading: false,
+        data: {
+          id: snapshot.id,
+          ...snapshot.data(),
+        },
+        error: null,
+        snapshot,
+      });
+    }
   };
 
   render() {

--- a/src/__tests__/collection.firestore-error.js
+++ b/src/__tests__/collection.firestore-error.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { FirestoreCollection } from '../';
+import { createMocksForCollection } from './helpers/firestore-utils';
+
+test('should handle error getting snapshot', () => {
+  const options = { onSnapshotMockError: true };
+  const {
+    firestoreMock,
+    collectionMock,
+    onSnapshotMock,
+  } = createMocksForCollection(null, options);
+  const renderMock = jest.fn().mockReturnValue(<div />);
+  const collectionName = 'error';
+
+  const wrapper = mount(
+    <FirestoreCollection path={collectionName} render={renderMock} />,
+    { context: { firestoreDatabase: firestoreMock, firestoreCache: {} } },
+  );
+
+  expect(collectionMock).toHaveBeenCalledTimes(1);
+  expect(collectionMock).toHaveBeenCalledWith(collectionName);
+  expect(onSnapshotMock).toHaveBeenCalledTimes(1);
+  expect(renderMock).toHaveBeenCalledTimes(2);
+  expect(renderMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      isLoading: true,
+      data: [],
+      error: null,
+      snapshot: null,
+    }),
+  );
+  expect(wrapper.state('error')).not.toBe(null);
+});

--- a/src/__tests__/document.firestore-error.js
+++ b/src/__tests__/document.firestore-error.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { FirestoreDocument } from '../';
+import { createMocksForDocument } from './helpers/firestore-utils';
+
+test('should handle error getting snapshot', () => {
+  const options = { onSnapshotMockError: true };
+  const {
+    firestoreMock,
+    documentMock,
+    onSnapshotMock,
+  } = createMocksForDocument(null, options);
+  const renderMock = jest.fn().mockReturnValue(<div />);
+  const documentPath = 'error/1';
+
+  const wrapper = mount(
+    <FirestoreDocument path={documentPath} render={renderMock} />,
+    {
+      context: { firestoreDatabase: firestoreMock, firestoreCache: {} },
+    },
+  );
+
+  expect(documentMock).toHaveBeenCalledTimes(1);
+  expect(documentMock).toHaveBeenCalledWith(documentPath);
+  expect(onSnapshotMock).toHaveBeenCalledTimes(1);
+  expect(renderMock).toHaveBeenCalledTimes(2);
+  expect(renderMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      isLoading: true,
+      data: null,
+      error: null,
+      snapshot: null,
+    }),
+  );
+  expect(wrapper.state('error')).not.toBe(null);
+});

--- a/src/__tests__/helpers/firestore-utils.js
+++ b/src/__tests__/helpers/firestore-utils.js
@@ -1,4 +1,4 @@
-export function createMocksForCollection(documentCollection) {
+export function createMocksForCollection(documentCollection, options = {}) {
   let snapshot;
 
   if (documentCollection) {
@@ -14,10 +14,10 @@ export function createMocksForCollection(documentCollection) {
     };
   }
 
-  return createBaseMocks(snapshot);
+  return createBaseMocks(snapshot, options);
 }
 
-export function createMocksForDocument(doc) {
+export function createMocksForDocument(doc, options = {}) {
   let snapshot;
 
   if (doc) {
@@ -29,13 +29,17 @@ export function createMocksForDocument(doc) {
     };
   }
 
-  return createBaseMocks(snapshot);
+  return createBaseMocks(snapshot, options);
 }
 
-function createBaseMocks(snapshot) {
+function createBaseMocks(snapshot, options) {
   const unsubscribeMock = jest.fn();
-  const onSnapshotMock = jest.fn(cb => {
-    cb(snapshot);
+  const onSnapshotMock = jest.fn((successCb, errorCb) => {
+    if (options && options.onSnapshotMockError) {
+      errorCb(new Error('Error with snapshot'));
+    } else {
+      successCb(snapshot);
+    }
 
     return unsubscribeMock;
   });


### PR DESCRIPTION
Closes #12.

The code from @sampl was slightly modifed in order for existing tests to pass, and tests were added to ensure that the FirestoreCollection and FirestoreDocument components react accordingly to firestore query errors.