### PR TITLE
Added fix to prevent error for Firestore v5.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ At the top level of your app, configure `firebase` and render the
 If you're using [create-react-app][create-react-app], your `index.js`
 file would look something like this:
 
+
 ```jsx
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -107,6 +108,11 @@ ReactDOM.render(
   document.getElementById('root'),
 );
 ```
+
+_Important: Starting with Firebase v5.5.0 timestamp objects stored in Firestore get returned as Firebase
+Timestamp objects instead of regular Date() objects. To make your app compatible with this
+change, add the `useTimestampsInSnapshots` to the FirestoreProvider element. If you dont do this
+your app might break. For more information visit [the Firebase refrence documentation][https://firebase.google.com/docs/reference/js/firebase.firestore.Timestamp]._
 
 _Note: The reason for the separate imports for `@firebase/app` and `@firebase/firestore`
 is because `firestore` is not included in the default `firebase` wrapper package. See

--- a/src/FirestoreProvider.js
+++ b/src/FirestoreProvider.js
@@ -6,6 +6,7 @@ export default class FirestoreProvider extends Component {
   static propTypes = {
     firebase: PropTypes.object.isRequired,
     children: PropTypes.node.isRequired,
+    useTimestampsInSnapshots: PropTypes.bool.isRequired
   };
 
   static defaultProps = {

--- a/src/FirestoreProvider.js
+++ b/src/FirestoreProvider.js
@@ -6,6 +6,7 @@ export default class FirestoreProvider extends Component {
   static propTypes = {
     firebase: PropTypes.object.isRequired,
     children: PropTypes.node.isRequired,
+    useTimestampsInSnapshots: PropTypes.bool.isRequired,
   };
 
   static childContextTypes = {
@@ -19,7 +20,7 @@ export default class FirestoreProvider extends Component {
     const { firebase } = props;
 
     this.state = {
-      firestoreDatabase: firebase.firestore({timestampsInSnapshots: true}),
+      firestoreDatabase: firebase.firestore({timestampsInSnapshots: this.props.useTimestampsInSnapshots}),
       firestoreCache: new FirestoreCache(),
     };
   }

--- a/src/FirestoreProvider.js
+++ b/src/FirestoreProvider.js
@@ -19,7 +19,7 @@ export default class FirestoreProvider extends Component {
     const { firebase } = props;
 
     this.state = {
-      firestoreDatabase: firebase.firestore(),
+      firestoreDatabase: firebase.firestore({timestampsInSnapshots: true}),
       firestoreCache: new FirestoreCache(),
     };
   }

--- a/src/FirestoreProvider.js
+++ b/src/FirestoreProvider.js
@@ -6,8 +6,11 @@ export default class FirestoreProvider extends Component {
   static propTypes = {
     firebase: PropTypes.object.isRequired,
     children: PropTypes.node.isRequired,
-    useTimestampsInSnapshots: PropTypes.bool.isRequired,
   };
+
+  static defaultProps = {
+    useTimestampsInSnapshots: false
+  }
 
   static childContextTypes = {
     firestoreDatabase: PropTypes.object.isRequired,


### PR DESCRIPTION
This message shows up now... added the fix as described.

```
@firebase/firestore: Firestore (5.5.0): 
The behavior for Date objects stored in Firestore is going to change
AND YOUR APP MAY BREAK.
To hide this warning and ensure your app does not break, you need to add the
following code to your app before calling any other Cloud Firestore methods:

  const firestore = firebase.firestore();
  const settings = {/* your settings... */ timestampsInSnapshots: true};
  firestore.settings(settings);

With this change, timestamps stored in Cloud Firestore will be read back as
Firebase Timestamp objects instead of as system Date objects. So you will also
need to update code expecting a Date to instead expect a Timestamp. For example:

  // Old:
  const date = snapshot.get('created_at');
  // New:
  const timestamp = snapshot.get('created_at');
  const date = timestamp.toDate();

Please audit all existing usages of Date when you enable the new behavior. In a
future release, the behavior will change to the new behavior, so if you do not
follow these steps, YOUR APP MAY BREAK.
```