### PR TITLE
Only set timestampsInSnapshots when explicitly requested via prop

### DIFF
--- a/src/FirestoreProvider.js
+++ b/src/FirestoreProvider.js
@@ -11,17 +11,17 @@ export default class FirestoreProvider extends Component {
     useTimestampsInSnapshots: PropTypes.bool,
   };
 
-  static defaultProps = {
-    useTimestampsInSnapshots: false,
-  };
+  static defaultProps = {};
 
   constructor(props) {
     super(props);
 
     const { firebase, useTimestampsInSnapshots } = props;
-    const settings = { timestampsInSnapshots: useTimestampsInSnapshots };
     const firestore = firebase.firestore();
-    firestore.settings(settings);
+    if (typeof useTimestampsInSnapshots !== 'undefined') {
+      const settings = { timestampsInSnapshots: useTimestampsInSnapshots };
+      firestore.settings(settings);
+    }
 
     this.state = {
       firestoreDatabase: firestore,

--- a/src/__tests__/provider.firestore-settings.js
+++ b/src/__tests__/provider.firestore-settings.js
@@ -15,10 +15,7 @@ test('sets timestampsInSnapshots correctly', () => {
     </FirestoreProvider>,
   );
 
-  expect(firestore.settings).toHaveBeenCalledTimes(1);
-  expect(firestore.settings).toHaveBeenCalledWith({
-    timestampsInSnapshots: false,
-  });
+  expect(firestore.settings).toHaveBeenCalledTimes(0);
 
   mount(
     <FirestoreProvider firebase={firebase} useTimestampsInSnapshots>
@@ -26,8 +23,19 @@ test('sets timestampsInSnapshots correctly', () => {
     </FirestoreProvider>,
   );
 
-  expect(firestore.settings).toHaveBeenCalledTimes(2);
+  expect(firestore.settings).toHaveBeenCalledTimes(1);
   expect(firestore.settings).toHaveBeenCalledWith({
     timestampsInSnapshots: true,
+  });
+
+  mount(
+    <FirestoreProvider firebase={firebase} useTimestampsInSnapshots={false}>
+      <div>Test</div>
+    </FirestoreProvider>,
+  );
+
+  expect(firestore.settings).toHaveBeenCalledTimes(2);
+  expect(firestore.settings).toHaveBeenCalledWith({
+    timestampsInSnapshots: false,
   });
 });


### PR DESCRIPTION
As of firebase@5.8.x `timestampsInSnapshots` seems to be `true` implicitly
(example: https://github.com/green-arrow/react-firestore/issues/39 ) i.e. the corresponding prop and logic in react-firestore is unneccessary for anyone who is up-to-date. This PR keeps the prop around for backwards compatibility, but only acts on it when set explicitly.

Furthermore: another reason not calling settings() implicitly and unconditionally
within react-firestore: calling settings() multiple times is not supported.

If your app interacts with Firestore prior to using FirestoreProvider,
FirestoreProvider's settings() call will get you into trouble:

> Uncaught FirebaseError: Firestore has already been started
and its settings can no longer be changed. You can only call settings()
before calling any other methods on a Firestore object

(This PR is possibly also a more graceful alternative to https://github.com/green-arrow/react-firestore/pull/37 )

